### PR TITLE
Removed deprecated battery attributes from VacuumStateEntity

### DIFF
--- a/custom_components/homewizard_vacuum/manifest.json
+++ b/custom_components/homewizard_vacuum/manifest.json
@@ -8,6 +8,6 @@
     "issue_tracker": "https://github.com/srkoster/hass-hw-cleaner/issues",
     "loggers": ["hw_cleaner"],
     "requirements": [],
-    "version": "2.1.1"
+    "version": "2.2.0"
   }
   

--- a/custom_components/homewizard_vacuum/sensor.py
+++ b/custom_components/homewizard_vacuum/sensor.py
@@ -5,7 +5,7 @@ from .base import HWCleanerBaseEntity
 from .const import DOMAIN, CONF_IDENTIFIER
 from .coordinator import HWCleanerCoordinator
 
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.core import HomeAssistant
@@ -40,8 +40,10 @@ class HWVacuumBrushSensor(HWCleanerBaseEntity, SensorEntity):
 
     entity_description = SensorEntityDescription(
         key="brush",
-        icon="mdi:hvac"
+        icon="mdi:hvac",
+        entity_category=EntityCategory.DIAGNOSTIC
     )
+    
 
     @property
     def state(self):
@@ -58,7 +60,8 @@ class HWVacuumStatusSensor(HWCleanerBaseEntity, SensorEntity):
 
     entity_description = SensorEntityDescription(
         key="status",
-        icon="mdi:list-status"
+        icon="mdi:list-status",
+        entity_category=EntityCategory.DIAGNOSTIC
     )
 
     @property
@@ -76,7 +79,8 @@ class HWVacuumFaultsSensor(HWCleanerBaseEntity, SensorEntity):
 
     entity_description = SensorEntityDescription(
         key="faults",
-        icon="mdi:alert-circle"
+        icon="mdi:alert-circle",
+        entity_category=EntityCategory.DIAGNOSTIC
     )
 
     @property
@@ -97,7 +101,8 @@ class HWVacuumBatterySensor(HWCleanerBaseEntity, SensorEntity):
         icon="mdi:battery",
         state_class=SensorStateClass.MEASUREMENT,
         native_unit_of_measurement=PERCENTAGE,
-        device_class=SensorDeviceClass.BATTERY
+        device_class=SensorDeviceClass.BATTERY,
+        entity_category=EntityCategory.DIAGNOSTIC
     )
 
     @property

--- a/custom_components/homewizard_vacuum/switch.py
+++ b/custom_components/homewizard_vacuum/switch.py
@@ -11,6 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.core import HomeAssistant
 from homeassistant.components.switch import SwitchEntity
+from homeassistant.const import EntityCategory
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -30,6 +31,8 @@ async def async_setup_entry(
 
 class HWVacuumSoundSwitch(HWCleanerBaseEntity, SwitchEntity):
     """Sensor entity for the vacuum's sound type."""
+    
+    _attr_entity_category = EntityCategory.CONFIG
     
     @property
     def available(self):

--- a/custom_components/homewizard_vacuum/vacuum.py
+++ b/custom_components/homewizard_vacuum/vacuum.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv, entity_platform
+from homeassistant.const import EntityCategory
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -90,6 +91,7 @@ class HWVacuumCleaner(HWCleanerBaseEntity, StateVacuumEntity):
 
     _attr_fan_speed_list = FAN_SPEEDS
     _attr_supported_features = SUPPORT_VACUUM
+    _attr_entity_category = EntityCategory.CONFIG
 
     @property
     def activity(self) -> VacuumActivity | None:

--- a/custom_components/homewizard_vacuum/vacuum.py
+++ b/custom_components/homewizard_vacuum/vacuum.py
@@ -43,8 +43,7 @@ CLEANER_STATUS_TO_HA = {
 }
 
 SUPPORT_VACUUM = (
-    VacuumEntityFeature.BATTERY
-    | VacuumEntityFeature.CLEAN_SPOT
+    VacuumEntityFeature.CLEAN_SPOT
     | VacuumEntityFeature.FAN_SPEED
     | VacuumEntityFeature.RETURN_HOME
     | VacuumEntityFeature.SEND_COMMAND
@@ -96,10 +95,6 @@ class HWVacuumCleaner(HWCleanerBaseEntity, StateVacuumEntity):
     def activity(self) -> VacuumActivity | None:
         status = self.coordinator._attr_device_status
         return CLEANER_STATUS_TO_HA.get(status, VacuumActivity.IDLE)
-
-    @property
-    def battery_level(self):
-        return self.coordinator._attr_battery_percentage
 
     @property
     def device_id(self):

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
     "name": "Homewizard Vacuum Cleaner",
-    "homeassistant": "2025.1.0"
+    "homeassistant": "2025.8.0"
 }


### PR DESCRIPTION
- Removed deprecated battery attributes from VacuumStateEntity (see https://developers.home-assistant.io/blog/2025/07/02/vacuum-battery-properties-deprecated)
- Added entity category to all entities for better classification
- Bump to version 2.2.0